### PR TITLE
Add support for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(
 
 target_link_libraries(${PROJECT_NAME}
   SCServo
-  yaml-cpp
+  yaml-cpp::yaml-cpp
 )
 
 ament_target_dependencies(${PROJECT_NAME}

--- a/include/SCServo_Linux/SCSerial.cpp
+++ b/include/SCServo_Linux/SCSerial.cpp
@@ -62,14 +62,16 @@ bool SCSerial::begin(int baudRate, const char* serialPort)
     case 115200:
         CR_BAUDRATE = B115200;
         break;
+#ifndef __APPLE__
     case 500000:
         CR_BAUDRATE = B500000;
         break;
     case 1000000:
         CR_BAUDRATE = B1000000;
         break;
+#endif
     default:
-		CR_BAUDRATE = B115200;
+        CR_BAUDRATE = B115200;
         break;
     }
     cfsetispeed(&curopt, CR_BAUDRATE);
@@ -119,10 +121,12 @@ int SCSerial::setBaudRate(int baudRate)
         break;
     case 230400:
         CR_BAUDRATE = B230400;
-	break;
+        break;
+#ifndef __APPLE__
     case 500000:
         CR_BAUDRATE = B500000;
         break;
+#endif
     default:
         break;
     }


### PR DESCRIPTION
Minor changes to support compilation on macOS. 

System: macOS Sequoia 15.3
Compiler: Apple clang 16.0.0 (Xcode 15.2).

- The macOS SDK does not support literals for some baud rates.
- Use the cmake target yaml-cpp::yaml-cpp instead of yaml-cpp