### PR TITLE
Allow higher serial baud rates on macOS

### DIFF
--- a/include/SCServo_Linux/SCSerial.cpp
+++ b/include/SCServo_Linux/SCSerial.cpp
@@ -7,6 +7,12 @@
 
 #include "SCSerial.h"
 
+#if __APPLE__
+#include <sys/ioctl.h>
+
+#define IOSSIOSPEED 0x80045402
+#endif
+
 SCSerial::SCSerial()
 {
 	IOTimeOut = 100;
@@ -69,6 +75,13 @@ bool SCSerial::begin(int baudRate, const char* serialPort)
     case 1000000:
         CR_BAUDRATE = B1000000;
         break;
+#else // on macOS termios.h does not define the following baud rates
+    case 500000:
+        CR_BAUDRATE = 500000;
+        break;
+    case 1000000:
+        CR_BAUDRATE = 1000000;
+        break;
 #endif
     default:
         CR_BAUDRATE = B115200;
@@ -87,12 +100,28 @@ bool SCSerial::begin(int baudRate, const char* serialPort)
     curopt.c_cflag |= CLOCAL;//disable modem statuc check
     cfmakeraw(&curopt);//make raw mode
     curopt.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
+#ifndef __APPLE__
     if(tcsetattr(fd, TCSANOW, &curopt) == 0){
         return true;
     }else{
 		perror("tcsetattr:");
 		return false;
 	}
+#else
+    // On macOS termios.h defines a max baud rate of B230400.
+    // Higher rates are availble using the IOSSIOSPEED ioctl.
+    cfsetispeed(&curopt, B230400);
+    cfsetospeed(&curopt, B230400);
+    if(tcsetattr(fd, TCSANOW, &curopt) != 0) {
+        perror("tcsetattr:");
+        return false;
+    } else if(ioctl(fd, IOSSIOSPEED, &baudRate) == 0) {
+        return true;
+    } else {
+        perror("ioctl:");
+        return false;
+    }
+#endif
 }
 
 int SCSerial::setBaudRate(int baudRate)
@@ -125,6 +154,16 @@ int SCSerial::setBaudRate(int baudRate)
 #ifndef __APPLE__
     case 500000:
         CR_BAUDRATE = B500000;
+        break;
+    case 1000000:
+        CR_BAUDRATE = B1000000;
+        break;
+#else // on macOS termios.h does not define the following baud rate
+    case 500000:
+        CR_BAUDRATE = 500000;
+        break;
+    case 1000000:
+        CR_BAUDRATE = 1000000;
         break;
 #endif
     default:


### PR DESCRIPTION
On macOS, `termios.h` limits the max baud rate to 230400, however higher serial baud rates are available by using the `IOSSIOSPEED`  `ioctl`. This is needed as the default baud rate for the Feetech STS3215 serial bus servos is 1000000.

This PR uses `ioctl` on macOS to set the higher baud rates than otherwise available via `tcsetattr`.

The serial flags are first set using `tcsetattr` with a temporary baud rate chosen to be the highest defined for macOS in `termios.h`. The baud rate is then set to the desired value using `ioctl`.

#### Testing

Run the `test_servo` utility on a SO-101 arm:

```bash
(ros2-3.13) rhys@MacBookPro2-2 ros2-arm % ./install/so_arm_100_hardware/lib/so_arm_100_hardware/test_servo
serial:/dev/cu.usbmodem5B140341111
serial speed 1000000

Reading servo 1...
  Position: 3114 (0-4095)
  Speed: 0
  Load: 0
  Voltage: 7.3V
  Temperature: 27°C
  Moving: no

Reading servo 2...
  Position: 793 (0-4095)
  Speed: 0
  Load: 0
  Voltage: 5.2V
  Temperature: 28°C
  Moving: no

Reading servo 3...
  Position: 3033 (0-4095)
  Speed: 0
  Load: 0
  Voltage: 7.4V
  Temperature: 27°C
  Moving: no

Reading servo 4...
  Position: 2952 (0-4095)
  Speed: 0
  Load: 0
  Voltage: 7.3V
  Temperature: 28°C
  Moving: no

Reading servo 5...
  Position: 2045 (0-4095)
  Speed: 0
  Load: 0
  Voltage: 7.3V
  Temperature: 27°C
  Moving: no

Reading servo 6...
  Position: 1551 (0-4095)
  Speed: 0
  Load: 0
  Voltage: 7.3V
  Temperature: 28°C
  Moving: no
```

#### Links and discussion

- https://github.com/avrdudes/avrdude/issues/771
- https://fpc-pascal.freepascal.narkive.com/oI4b0CM2/non-standard-baud-rates-in-os-x-iossiospeed-ioctl
- https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/ioctl.2.html
- https://discussions.apple.com/thread/1587991?sortBy=rank