### PR TITLE
Fix compiler warnings in test examples

### DIFF
--- a/test/ping_test.cpp
+++ b/test/ping_test.cpp
@@ -5,7 +5,7 @@
 
 SMS_STS sm_st;
 
-int main(int argc, char **argv)
+int main(int /*argc*/, char ** /*argv*/)
 {
     const char* port = "/dev/ttyUSB0";  // Use absolute path
     std::cout<<"serial:"<<port<<std::endl;

--- a/test/test_servo.cpp
+++ b/test/test_servo.cpp
@@ -5,7 +5,7 @@
 
 SMS_STS sm_st;
 
-int main(int argc, char **argv)
+int main(int /*argc*/, char ** /*argv*/)
 {
     const char* port = "/dev/ttyUSB0";
     std::cout << "serial:" << port << std::endl;


### PR DESCRIPTION
Minor change to remove `unused variable` compiler warnings on clang. 