### PR TITLE
Provide parameters to configure the servo speed and acceleration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ so_arm_100:
     use_serial: true  # Set to true for real robot, false for simulation
     serial_port: "/dev/ttyUSB0"  # Serial port for real robot
     serial_baudrate: 1000000  # Serial baudrate
+    servo_speed: 2400  # Servo speed in ticks / second
+    servo_acceleration: 50  # Servo acceleration in ticks / second / second
 ```
 
 ### Serial Communication Mode

--- a/config/hardware_config.yaml
+++ b/config/hardware_config.yaml
@@ -3,4 +3,6 @@ so_arm_100_hardware:
     use_serial: true
     serial_port: "/dev/ttyUSB0"
     serial_baudrate: 1000000
+    servo_speed: 2400
+    servo_acceleration: 50
     calibration_file: "$(find so_arm_100_hardware)/config/calibration.yaml"

--- a/include/so_arm_100_hardware/so_arm_100_interface.hpp
+++ b/include/so_arm_100_hardware/so_arm_100_interface.hpp
@@ -69,6 +69,12 @@ private:
   std::string serial_port_;
   int serial_baudrate_;
 
+  // Servo speed in ticks per second
+  u16 servo_speed_;
+
+  // Servo acceleration in ticks per second per second
+  u8 servo_acceleration_;
+
   // Serial communication
   int SerialPort;
   struct termios tty;

--- a/src/so_arm_100_interface.cpp
+++ b/src/so_arm_100_interface.cpp
@@ -46,6 +46,12 @@ CallbackReturn SOARM100Interface::on_init(const hardware_interface::HardwareComp
     serial_baudrate_ = params.hardware_info.hardware_parameters.count("serial_baudrate") ?
         std::stoi(params.hardware_info.hardware_parameters.at("serial_baudrate")) : 1000000;
 
+    servo_speed_ = params.hardware_info.hardware_parameters.count("servo_speed") ?
+        std::stoi(params.hardware_info.hardware_parameters.at("servo_speed")) : 2400;
+
+    servo_acceleration_ = params.hardware_info.hardware_parameters.count("servo_acceleration") ?
+        std::stoi(params.hardware_info.hardware_parameters.at("servo_acceleration")) : 50;
+
     size_t num_joints = info_.joints.size();
     position_commands_.resize(num_joints, 0.0);
     position_states_.resize(num_joints, 0.0);
@@ -192,7 +198,7 @@ hardware_interface::return_type SOARM100Interface::write(const rclcpp::Time & /*
                        "Servo %d command: %.2f rad -> %d ticks", 
                        servo_id, position_commands_[i], joint_pos_cmd);
             
-            if (!st3215_.RegWritePosEx(servo_id, joint_pos_cmd, 4500, 255)) {
+            if (!st3215_.RegWritePosEx(servo_id, joint_pos_cmd, servo_speed_, servo_acceleration_)) {
                 RCLCPP_WARN(rclcpp::get_logger("SOARM100Interface"), 
                            "Failed to write position to servo %d", servo_id);
             }


### PR DESCRIPTION
Add parameters to configure the speed and acceleration arguments to RegWritePosEx.

### Details

The new parameters are

- servo_speed (ticks/s)
- servo_acceleration (ticks/s^2)

A lower value of `servo_acceleration` reduces jerk in the arm motion.

Suggested here:

- https://github.com/leochien1110/so101_ws?tab=readme-ov-file#servo-motion-smoothing-feetech-sts3215

Question:

May better to use SI units and use the conversion functions. Using ticks is probably ok for a hardware driver?