### PR TITLE
Rename arm and gripper controllers

### DIFF
--- a/scripts/jog_joints.py
+++ b/scripts/jog_joints.py
@@ -40,13 +40,13 @@ class JogTool(Node):
         self.arm_client = ActionClient(
             self,
             FollowJointTrajectory,
-            '/so_100_arm_controller/follow_joint_trajectory'
+            '/arm_controller/follow_joint_trajectory'
         )
         
         # For gripper control
         self.gripper_pub = self.create_publisher(
             JointTrajectory,
-            '/so_100_arm_gripper_controller/commands',
+            '/gripper_controller/commands',
             10)
         
         # For toggling torque

--- a/scripts/zero_pose.py
+++ b/scripts/zero_pose.py
@@ -11,7 +11,7 @@ class ZeroPoseTest(Node):
         # Create publisher for arm controller
         self.arm_pub = self.create_publisher(
             JointTrajectory, 
-            '/so_100_arm_controller/joint_trajectory', 
+            '/arm_controller/joint_trajectory', 
             10)
             
         # Joint names in order


### PR DESCRIPTION
Use shorter names for arm and gripper controllers. 

- `/arm_controller` for the `joint_trajectory_controller/JointTrajectoryController`.
- `/gripper_controller` for the `position_controllers/JointGroupPositionController`.

See discussion

- https://github.com/brukg/SO-100-arm/issues/12#issuecomment-4049982684

Tasks

- [x] raise PR for coordinated change in https://github.com/brukg/SO-100-arm 