### PR TITLE
Apply stored position offset in velocity and effort control modes

### DIFF
--- a/include/so_arm_100_hardware/so_arm_100_interface.hpp
+++ b/include/so_arm_100_hardware/so_arm_100_interface.hpp
@@ -93,6 +93,9 @@ private:
   // Default control mode (0=position, 1=velocity, 2=effort/PWM)
   uint8_t default_control_mode_;
 
+  // Servo position offsets in ticks 
+  std::vector<int> servo_position_offsets_;
+
   // Serial communication
   int SerialPort;
   struct termios tty;

--- a/src/so_arm_100_interface.cpp
+++ b/src/so_arm_100_interface.cpp
@@ -65,6 +65,7 @@ CallbackReturn SOARM100Interface::on_init(const hardware_interface::HardwareComp
     effort_commands_.resize(num_joints, 0.0);
     effort_states_.resize(num_joints, 0.0);
     active_control_mode_.resize(num_joints, default_control_mode_);
+    servo_position_offsets_.resize(num_joints, 0);
 
     return CallbackReturn::SUCCESS;
 }
@@ -152,6 +153,20 @@ CallbackReturn SOARM100Interface::on_activate(const rclcpp_lifecycle::State & /*
 {
     RCLCPP_INFO(rclcpp::get_logger("SOARM100Interface"), "Activating so_arm_100 hardware interface...");
 
+    // Read the position offset from EPROM
+    auto read_pos_offset = [this](uint8_t servo_id) -> int {
+        int raw_pos_offset = -1;
+        int err = 0;
+        raw_pos_offset = st3215_.readWord(servo_id, SMS_STS_OFS_L);
+        if (raw_pos_offset == -1) {
+            err = 1;
+        }
+        if (!err && (raw_pos_offset&(1<<15))) {
+            raw_pos_offset = -(raw_pos_offset&~(1<<15));
+        }
+        return raw_pos_offset;
+    };
+
     if (use_serial_) {
         if(!st3215_.begin(serial_baudrate_, serial_port_.c_str())) {
             RCLCPP_ERROR(rclcpp::get_logger("SOARM100Interface"), "Failed to initialize motors");
@@ -185,7 +200,13 @@ CallbackReturn SOARM100Interface::on_activate(const rclcpp_lifecycle::State & /*
                 RCLCPP_INFO(rclcpp::get_logger("SOARM100Interface"), 
                            "Servo %d initialized at position %d", servo_id, pos);
             }
-            
+
+            // Read the position offset from servo EPROM.
+            int raw_pos_offset = read_pos_offset(servo_id);
+            RCLCPP_DEBUG(rclcpp::get_logger("SOARM100Interface"),
+                        "Servo %d: raw_pos_offset=%d", servo_id, raw_pos_offset);
+            servo_position_offsets_[i] = raw_pos_offset;
+
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
         
@@ -331,7 +352,14 @@ hardware_interface::return_type SOARM100Interface::write(const rclcpp::Time & /*
 
 hardware_interface::return_type SOARM100Interface::read(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
 {
-    if (use_serial_) {
+  // Apply position offset to the raw position
+  auto apply_pos_offset = [](int pos, int pos_offset) -> int {
+    int homing_offset = pos_offset > 2048 ? 2048 - pos_offset : pos_offset;
+    int offset_pos = (pos - homing_offset) % 4096;
+    return offset_pos;
+  };
+
+  if (use_serial_) {
         for (size_t i = 0; i < info_.joints.size(); ++i) {
             uint8_t servo_id = static_cast<uint8_t>(i + 1);
 
@@ -339,6 +367,11 @@ hardware_interface::return_type SOARM100Interface::read(const rclcpp::Time & /*t
                 // When torque is disabled, only try to read position
                 int raw_pos = st3215_.ReadPos(servo_id);
                 if (raw_pos != -1) {
+                    // Apply position offset in velocity and effort modes
+                    int raw_pos_offset = servo_position_offsets_[i];
+                    if (active_control_mode_[i] != 0 && raw_pos_offset != 0) {
+                        raw_pos = apply_pos_offset(raw_pos, raw_pos_offset);
+                    }
                     position_states_[i] = ticks_to_radians(raw_pos, i);
                 }
                 continue;  // Skip other reads
@@ -348,6 +381,11 @@ hardware_interface::return_type SOARM100Interface::read(const rclcpp::Time & /*t
             // in one serial transaction. Use -1 for subsequent reads to use cached data.
             if (st3215_.FeedBack(servo_id) != -1) {
                 int raw_pos = st3215_.ReadPos(-1);
+                // Apply position offset in velocity and effort modes
+                int raw_pos_offset = servo_position_offsets_[i];
+                if (active_control_mode_[i] != 0 && raw_pos_offset != 0) {
+                    raw_pos = apply_pos_offset(raw_pos, raw_pos_offset);
+                }
                 position_states_[i] = ticks_to_radians(raw_pos, i);
 
                 velocity_states_[i] = st3215_.ReadSpeed(-1) * 2.0 * M_PI / 4096.0;


### PR DESCRIPTION
Ensure that when a non-zero position offset is saved in the servo EPROM, the servo position reported by the hardware interface is consistent in all control modes.

- The stored position offset is only applied to the position returned by `ReadPos` when in position control mode.
- Ensure consistent position reporting in velocity and effort modes when the position offset is non-zero.

See discussion: https://github.com/brukg/SO-100-arm/issues/12#issuecomment-4066767151